### PR TITLE
Manifest generation and pushing to registry

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,14 +10,15 @@ import (
 
 // Registry is the struct for single registry config
 type Registry struct {
-	Platform   string
-	ImageURL   string `yaml:"image-url,omitempty"`
-	URL        string `yaml:"registry-url,omitempty"`
-	Username   string
-	Password   string
-	Repository string
-	AccountID  string `yaml:"account-id,omitempty"`
-	Region     string
+	Platform     string
+	ImageURL     string `yaml:"image-url,omitempty"`
+	URL          string `yaml:"registry-url,omitempty"`
+	Username     string
+	Password     string
+	Repository   string
+	AccountID    string `yaml:"account-id,omitempty"`
+	Region       string
+	WithManifest bool `yaml:"upload-manifest,omitempty"`
 }
 
 // Config is the configuration for the benchmark

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,12 @@ require (
 	github.com/containerd/containerd v1.4.0
 	github.com/containerd/ttrpc v1.0.1 // indirect
 	github.com/containerd/typeurl v1.0.1 // indirect
+	github.com/docker/distribution v2.7.1+incompatible
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200901185902-ae0ef82b9035+incompatible
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
 	github.com/docker/go-units v0.4.0 // indirect
+	github.com/docker/libtrust v0.0.0-20160708172513-aabc10ec26b7
 	github.com/heroku/docker-registry-client v0.0.0-20190909225348-afc9e1acc3d5
 	github.com/imdario/mergo v0.3.11 // indirect
 	github.com/influxdata/influxdb1-client v0.0.0-20200827194710-b269163b24ab

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZm
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/distribution v0.0.0-20171011171712-7484e51bf6af h1:ujR+JcSHkOZMctuIgvi+a/VHpTn0nSy0W7eV5p34xjg=
 github.com/docker/distribution v0.0.0-20171011171712-7484e51bf6af/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
+github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200901185902-ae0ef82b9035+incompatible h1:c9WM5gpkKJEubPR1FmEFk1gw53qmL+NjyrnuP8cz3UE=
 github.com/docker/docker v17.12.0-ce-rc1.0.20200901185902-ae0ef82b9035+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/imggen/imggen.go
+++ b/imggen/imggen.go
@@ -93,5 +93,6 @@ func Generate(yamlFilename string) string {
 
 		log.Printf("Docker layer generated")
 	}
+
 	return filepath
 }

--- a/imggen/manifest.go
+++ b/imggen/manifest.go
@@ -1,0 +1,81 @@
+package imggen
+
+import (
+	"crypto/rand"
+	"log"
+	"os"
+
+	"github.com/docker/distribution"
+	"github.com/docker/distribution/manifest/schema2"
+	"github.com/opencontainers/go-digest"
+)
+
+var (
+	configSize = 1024
+)
+
+// GenerateManifest generates manifest for imggen generated layers and returns config layer digest
+func GenerateManifest(items []os.FileInfo, yamlFilename string) (*schema2.DeserializedManifest, digest.Digest) {
+
+	layers := make([]distribution.Descriptor, len(items))
+	for i, item := range items {
+		digest := digest.NewDigestFromHex(
+			"sha256",
+			item.Name(),
+		)
+		layer := distribution.Descriptor{
+			Digest:    digest,
+			MediaType: schema2.MediaTypeLayer,
+			Size:      item.Size(),
+		}
+		layers[i] = layer
+	}
+
+	manifest := schema2.Manifest{
+		Versioned: schema2.SchemaVersion,
+		Layers:    layers,
+		Config:    createConfigFile(yamlFilename),
+	}
+
+	deserializedManifest, _ := schema2.FromStruct(manifest)
+	return deserializedManifest, deserializedManifest.Config.Digest
+}
+
+func createConfigFile(yamlFilename string) distribution.Descriptor {
+	fd, err := Create("config-file")
+	if err != nil {
+		log.Fatalf("Error creating file: %v", err)
+	}
+	size := int64(configSize)
+	fd.Seek(size-9, 0)
+
+	randbytes := make([]byte, 8)
+	rand.Read(randbytes)
+
+	fd.Write(randbytes)
+	fd.Write([]byte{0})
+
+	err = fd.Close()
+	if err != nil {
+		log.Fatal("Failed to close file")
+	}
+	configDigest, err := sha256Digest("config-file")
+	if err != nil {
+		log.Fatal(err)
+	}
+	digest := digest.NewDigestFromHex(
+		"sha256",
+		configDigest,
+	)
+
+	err = os.Rename("config-file", configDigest)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return distribution.Descriptor{
+		Digest:    digest,
+		MediaType: schema2.MediaTypeImageConfig,
+		Size:      size,
+	}
+}


### PR DESCRIPTION
Added because some registries (i.e. ECR) do not allow pulling layers that are not associated to any manifest.

- Add `with-manifest` flag to push manifest per each registry (quay has some issues with the generated manifest, therefore it is not possible to push the manifest there)